### PR TITLE
Added reputation hit when harass operation completed

### DIFF
--- a/md/betterpiracy_config.xml
+++ b/md/betterpiracy_config.xml
@@ -30,6 +30,7 @@
             $harass_bailing_pilots_destroy_components = 0,
             $combat_base_bail_chance = 36,
             $combat_reputation_hit = 1,
+            $combat_reputation_hit_scale = 1,
             $combat_bailing_pilots_damage_hull = 0,
             $combat_bailing_pilots_destroy_components = 0
           ]"
@@ -283,6 +284,19 @@
             $mouseover  = {61537, 5188},
             $type       = 'button',
             $default    = 1,
+            $callback   = OnChange
+          ]"
+        />
+        <signal_cue_instantly
+          cue = "md.Simple_Menu_Options.Register_Option"
+          param = "table[
+            $category   = {61537, 5150},  
+            $id         = '$combat_reputation_hit_scale',
+            $name       = {61537, 5193},
+            $mouseover  = {61537, 5194},
+            $type       = 'slidercell',
+            $default    = 1,
+            $args       = table[$min = 1, $max = 10],
             $callback   = OnChange
           ]"
         />

--- a/md/betterpiracy_harass.xml
+++ b/md/betterpiracy_harass.xml
@@ -431,8 +431,9 @@
 										<!-- Likely needs further balencing. Reward_Notoriety__Result must have a negative multiplyer as it is normally positive. -->
 										<set_value name="$RewardNotoriety" exact="$Reward_Notoriety__Result * -0.5"/>
 										<add_faction_relation faction="faction.player" otherfaction="$ClientOwner" value="$RewardNotoriety" reason="relationchangereason.boardedobject" />
-										<signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
+										
 									</do_if>
+								<signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
 								</do_if>
 							</actions>
 						</cue>

--- a/md/betterpiracy_harass.xml
+++ b/md/betterpiracy_harass.xml
@@ -61,6 +61,9 @@
 				<set_value name="$MissionStep_WaitBailing" exact="4"/>
 				<set_value name="$MissionStep_ClaimShip" exact="5"/>
 				<set_value name="$Harassers" exact="$MainHarasser.subordinates"/>
+				<set_value name="$ShipClass" exact="$Target.class"/> 
+				<set_value name="$Difficulty" exact="1"/> 
+				<set_value name="$ClientOwner" exact="$Target.owner"/> 
 				<debug_to_file name="'BetterPiracy'" text="'%s --- Betterpiracy_harass --- Harass operation created: $MissionCue = %s, $MainHarasser = %s (%s), $Target = %s (%s), $MaxDistance = %s.'.[player.age, $MissionCue, $MainHarasser.knownname, $MainHarasser.idcode, $Target.knownname, $Target.idcode, $MaxDistance]"/>
 			</actions>
 			<cues>
@@ -403,7 +406,33 @@
 							<actions>
 								<signal_objects object="$Target" param="$MissionCue" param2="'harass__end'"/>
 								<do_if value="$Target.owner == faction.player or not $Target.isoperational">
-									<signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
+									<do_if value="$Config.{'$combat_reputation_hit'} == 1">
+										<!-- This is the only place I could put it where the same logic will work for both boarding and claiming, 
+										users can cheat if they wish by simply canceling the operation. 
+										Ideally it would be better to occur when the pilot bails or when a ship is boarded.
+										The same logic can be applied to harass_reputation_hit, just include a smaller negative multiplyer. -->										
+										<do_if value="$ShipClass = class.ship_s">
+											<set_value name="$Difficulty" exact="level.veryeasy"/>
+										</do_if>
+										<do_if value="$ShipClass = class.ship_m">
+											<set_value name="$Difficulty" exact="level.easy"/>
+										</do_if>
+										<do_if value="$ShipClass = class.ship_l">
+											<set_value name="$Difficulty" exact="level.medium"/>
+										</do_if>
+										<do_if value="$ShipClass = class.ship_xl">
+											<set_value name="$Difficulty" exact="level.hard"/>
+										</do_if>
+										<do_if value="$ShipClass = class.station">
+											<set_value name="$Difficulty" exact="level.veryhard"/>
+										</do_if>
+										<!-- $MissionLevel of 1 to 10. 10 equals roughly double the base reward of 1 -->
+										<signal_cue_instantly cue="md.LIB_Reward_Balancing.Reward_Notoriety" param="[$MissionCue, $Difficulty, $combat_reputation_hit_scale, $ClientOwner]"/>
+										<!-- Likely needs further balencing. Reward_Notoriety__Result must have a negative multiplyer as it is normally positive. -->
+										<set_value name="$RewardNotoriety" exact="$Reward_Notoriety__Result * -0.5"/>
+										<add_faction_relation faction="faction.player" otherfaction="$ClientOwner" value="$RewardNotoriety" reason="relationchangereason.boardedobject" />
+										<signal_cue_instantly cue="Harass_ChangePhase" param="'finish'"/>
+									</do_if>
 								</do_if>
 							</actions>
 						</cue>

--- a/t/0001-l044.xml
+++ b/t/0001-l044.xml
@@ -68,6 +68,8 @@
     <t id="5190">(Combat bailing pilots damage hull mouseover)When enabled, after shooting a target until it bails the bailing pilot will further damage the ship.\n\nThe damage inflicted is proportional to the pilot morale.</t>
     <t id="5191">(Combat bailing pilots destroy components name)Combat bailing pilots destroy components</t>
     <t id="5192">(Combat bailing pilots destroy components mouseover)When enabled, after after shooting a target until it bails the bailing pilot will destroy some of the ship componets.\n\nThe number of componets destroyed is proportional to the pilot morale.</t>
+    <t id="5193">(Combat reputation hit scale name)Combat reputation hit scale</t>
+    <t id="5194">(Combat reputation hit mouseover)When enabled, changes the amount your reputation is changed, 1 is the base, 10 equals roughly double the hit. \n\nThe logic applied to determine if it happens is the same than when you board an L/XL ship.</t>
   </page>
   <!-- Threatening lines -->
   <page id="61538" title="Better piracy voices" descr="0" voice="yes">

--- a/t/0001.xml
+++ b/t/0001.xml
@@ -68,6 +68,8 @@
     <t id="5190">(Combat bailing pilots damage hull mouseover)When enabled, after shooting a target until it bails the bailing pilot will further damage the ship.\n\nThe damage inflicted is proportional to the pilot morale.</t>
     <t id="5191">(Combat bailing pilots destroy components name)Combat bailing pilots destroy components</t>
     <t id="5192">(Combat bailing pilots destroy components mouseover)When enabled, after after shooting a target until it bails the bailing pilot will destroy some of the ship componets.\n\nThe number of componets destroyed is proportional to the pilot morale.</t>
+    <t id="5193">(Combat reputation hit scale name)Combat reputation hit scale</t>
+    <t id="5194">(Combat reputation hit mouseover)When enabled, changes the amount your reputation is changed, 1 is the base, 10 equals roughly double the hit. \n\nThe logic applied to determine if it happens is the same than when you board an L/XL ship.</t>
   </page>
   <!-- Threatening lines -->
   <page id="61538" title="Better piracy voices" descr="0" voice="yes">


### PR DESCRIPTION
Added reputation hit when harass operation has been completed via claiming or successfully boarding.

It is the only place I could put it where the same logic will work for both boarding and claiming, users can cheat if they wish by simply canceling the operation. 
Ideally it would be better to occur when the pilot bails or when a ship is boarded.
The same logic can be applied to harass_reputation_hit, just include a smaller negative multiplier.

This likely needs to be balanced a little, but the included option scale "combat_reputation_hit_scale" can allow for self-customization.